### PR TITLE
Speedup & completion of download on errors.

### DIFF
--- a/bin/flickr-set-get
+++ b/bin/flickr-set-get
@@ -122,6 +122,7 @@ function getSet(setId, userId, commandOptions) {
   var numProcessed = 0;
   var numDownloaded = 0;
   var numSkipped = 0;
+  var numWarnings = 0;
 
   api.on('setInfo', function onSetInfo(info) {
     cli.info('Downloading ' + info.total + ' photos from "' + info.title + '" by ' + info.ownername);
@@ -142,9 +143,13 @@ function getSet(setId, userId, commandOptions) {
   });
 
   api.on('done', function onDone(results) {
-    cli.ok('All done. ' + numDownloaded + ' photos downloaded, ' + numSkipped + ' skipped');
+    cli.ok('All done. ' + numDownloaded + ' photos downloaded, ' + numSkipped + ' skipped, ' + numWarnings + ' warnings');
   });
 
+  api.on('warning', function onWarning(error) {
+    numWarnings++;
+    cli.error(error);
+  });
   api.on('error', function onError(error) {
     cli.error(error);
     process.exit(1);

--- a/lib/Flickr.js
+++ b/lib/Flickr.js
@@ -235,24 +235,24 @@ function Flickr(apiKey, options) {
           getPhotoSizes(photoId, function onGetPhotoSizes(err, sizes) {
 
             if (err) {
-              _this.emit('error', err);
-              return cb(err);
+              _this.emit('warning', err);
+              return cb(null, path);
             }
 
             _this.emit('photoSizes', photoId, sizes);
 
             if (!sizes[_this.options.size]) {
               var sizeErr = new Error('Size "' + _this.options.size + '" not available');
-              _this.emit('error', sizeErr);
+              _this.emit('warning', sizeErr);
 
-              return cb(sizeErr);
+              return cb(null, path);
             }
 
             download(sizes[_this.options.size].source, path, function onDownloadComplete() {
 
               if (err) {
-                _this.emit('error', err);
-                return cb(err);
+                _this.emit('warning', err);
+                return cb(null, path);
               }
 
               _this.emit('photoDownloaded', photoId, path);

--- a/lib/Flickr.js
+++ b/lib/Flickr.js
@@ -222,6 +222,16 @@ function Flickr(apiKey, options) {
       var tasks = info.photos.map(function mapTasks(currentValue, index, array) {
         var photoId = currentValue.id;
         return function asyncTask(cb) {
+          var path = _path.join(_this.options.outputDir, photoId + '.jpg');
+          if (_this.options.noOverwrite && fs.existsSync(path)) {
+            _this.emit('photoSkipped', photoId, path);
+            async.setImmediate(function onAsync() {
+              cb(null, path);
+            });
+
+            return;
+          }
+
           getPhotoSizes(photoId, function onGetPhotoSizes(err, sizes) {
 
             if (err) {
@@ -236,12 +246,6 @@ function Flickr(apiKey, options) {
               _this.emit('error', sizeErr);
 
               return cb(sizeErr);
-            }
-
-            var path = _path.join(_this.options.outputDir, photoId + '.jpg');
-            if (_this.options.noOverwrite && fs.existsSync(path)) {
-              _this.emit('photoSkipped', photoId, path);
-              return cb(null, path);
             }
 
             download(sizes[_this.options.size].source, path, function onDownloadComplete() {

--- a/tests/Flickr.js
+++ b/tests/Flickr.js
@@ -175,7 +175,7 @@ describe('Flickr', function ƒ() {
     it('should raise an error if a given size does not exists', function ƒ(done) {
       var f = new Flickr('apiKey', {concurrency: 1, outputDir: 'temp', size: 'Wrong size'});
 
-      f.on('error', function onError(error) {
+      f.on('warning', function onWarning(error) {
         rmDirSyncIfExists('temp');
         if (error.message.match(/Size "Wrong size" not available/)) {
           done();


### PR DESCRIPTION
1. When overwriting of files is turned off, the check if the file already exists should be moved before getting the available sizes of the image from Flickr. This highly speeds up the download process on repeated downloads.

2. Errors occuring while downloading an image should not abort the entire process of getting the whole set.